### PR TITLE
Flag derivative WRT map itself as not implemented in chain rule

### DIFF
--- a/src/LinearMaps.jl
+++ b/src/LinearMaps.jl
@@ -11,7 +11,7 @@ using SparseArrays
 
 import Statistics: mean
 
-using ChainRulesCore: unthunk, NoTangent, @thunk
+using ChainRulesCore: unthunk, NoTangent, @thunk, @not_implemented
 import ChainRulesCore: rrule
 
 using Base: require_one_based_indexing

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -2,8 +2,7 @@ function rrule(::typeof(*), A::LinearMap, x::AbstractVector)
     y = A*x
     function pullback(dy)
         DY = unthunk(dy)
-        # Because A is an abstract map, the product is only differentiable w.r.t the input
-        return NoTangent(), NoTangent(), @thunk(A' * DY)
+        return NoTangent(), @not_implemented("Gradient with respect to linear map itself not implemented."), @thunk(A' * DY)
     end
     return y, pullback
 end
@@ -12,8 +11,7 @@ function rrule(A::LinearMap, x::AbstractVector)
     y = A*x
     function pullback(dy)
         DY = unthunk(dy)
-        # Because A is an abstract map, the product is only differentiable w.r.t the input
-        return NoTangent(), @thunk(A' * DY)
+        return @not_implemented("Gradient with respect to linear map itself not implemented."), @thunk(A' * DY)
     end
     return y, pullback
 end


### PR DESCRIPTION
There are definitely scenarios where there ought to be a gradient WRT some parameters of the linear map, so this PR marks its gradient as not implemented rather than as `NoTangent()` to try to avoid correctness issues. Here's an example:
```
function f(p)
           A = LinearMap([p])
           return sum(A * [p])
end
# function is a fancy p^2, so gradient should be 2p
```

Annoyingly, this doesn't actually fix anything yet, at least for `Zygote`, because `Zygote` treats `NotImplemented`'s just like zeros (https://github.com/FluxML/Zygote.jl/issues/1204). But it still seems like the right thing to do.

