### PR TITLE
Streamline ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,16 @@ on:
       - master
   pull_request:
 
+permissions:
+  actions: write
+  contents: read
+
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.version == 'nightly' }}
     strategy:
-      fail-fast: false
       matrix:
         version:
           - '1.6'
@@ -20,19 +23,23 @@ jobs:
           - 'nightly'
         os:
           - ubuntu-latest
-          - macOS-latest
-          - windows-latest
+        include:
+          - os: windows-latest
+            version: '1'
+          - os: macOS-latest
+            version: '1'
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@latest
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
       - uses: julia-actions/cache@v2
-      - uses: julia-actions/julia-buildpkg@latest
-      - uses: julia-actions/julia-runtest@latest
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v4
         if: ${{ matrix.version == '1' && matrix.os == 'ubuntu-latest' }}
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           file: lcov.info
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
+        if: ${{ matrix.version == '1' && matrix.os == 'ubuntu-latest' }}
       - uses: codecov/codecov-action@v4
         if: ${{ matrix.version == '1' && matrix.os == 'ubuntu-latest' }}
         with:

--- a/test/trace.jl
+++ b/test/trace.jl
@@ -13,7 +13,7 @@ using LinearMaps, LinearAlgebra, Test
     @test tr(LinearMap{Int}(cumsum!, 10)) == 10
     @test tr(2LinearMap{Int}(cumsum!, 10)) == 20
     A = randn(3, 5); B = copy(transpose(A))
-    @test tr(A ⊗ B) == tr(kron(A, B))
+    @test tr(A ⊗ B) ≈ tr(kron(A, B))
     @test tr(A ⊗ B ⊗ A ⊗ B) ≈ tr(kron(A, B, A, B))
     A = randn(5, 5); B = copy(transpose(A))
     @test tr(A ⊗ B) ≈ tr(kron(A, B))


### PR DESCRIPTION
This polishes the ci.yml file a bit. It reduces the size of the version-matrix and excludes the buggy MacOS v1.6 case. It also adds permissions which are necessary(?)/recommended by the cache action.